### PR TITLE
Leveled Mobs Changes

### DIFF
--- a/LevelledMobs/settings.yml
+++ b/LevelledMobs/settings.yml
@@ -38,6 +38,8 @@ blacklisted-types:
   - 'ENDER_DRAGON'
   - 'WITHER'
   - 'RAVAGER'
+  - 'CREEPER'
+  - 'GUARDIAN'
 # - 'BABY_ZOMBIE'
 
 # Blacklisted Types Override: The mobs in here will be levelled regardless if they are included in 'blacklisted-types' or if 'level-passive' is true.


### PR DESCRIPTION
Blacklisted Guardians and Creepers (already powerful on there own).